### PR TITLE
error on clean using powershell

### DIFF
--- a/modman.php
+++ b/modman.php
@@ -1224,7 +1224,7 @@ class Modman_Resource_Remover{
      */
     public function doRemoveFolderRecursively($sFolderName){
 
-        $oDirectoryIterator = new RecursiveDirectoryIterator($sFolderName);
+        $oDirectoryIterator = new RecursiveDirectoryIterator($sFolderName, FilesystemIterator::SKIP_DOTS);
         /** @var SplFileInfo $oElement */
         foreach (new RecursiveIteratorIterator($oDirectoryIterator, RecursiveIteratorIterator::CHILD_FIRST) as $oElement){
             $this->doRemoveResource($oElement->getPathname());


### PR DESCRIPTION
I am getting the error "A resource must be a file, an empty folder or a symlink" when going through the clean process on PowerShell.  While doing some debugging I found that the RecursiveDirectoryIterator was calling delete on the "." directory.  I have added the FilesystemIterator::SKIP_DOTS flag to get around the issue.